### PR TITLE
Feature/faster reconciliation

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ContainerSolutions/argus/operator/internal/controller/resourceattestation"
 	"github.com/ContainerSolutions/argus/operator/internal/controller/resourceimplementation"
 	"github.com/ContainerSolutions/argus/operator/internal/controller/resourcerequirement"
+	"github.com/ContainerSolutions/argus/operator/internal/metrics"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -61,6 +62,7 @@ func main() {
 	var probeAddr string
 	var lvl zapcore.Level
 	var enc zapcore.TimeEncoder
+	metrics.SetUpMetrics()
 	lvlErr := lvl.UnmarshalText([]byte("info"))
 	if lvlErr != nil {
 		setupLog.Error(lvlErr, "error unmarshalling loglevel")

--- a/operator/internal/controller/resourcerequirement/resourcerequirement_controller.go
+++ b/operator/internal/controller/resourcerequirement/resourcerequirement_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	argusiov1alpha1 "github.com/ContainerSolutions/argus/operator/api/v1alpha1"
+	"github.com/ContainerSolutions/argus/operator/internal/metrics"
 	lib "github.com/ContainerSolutions/argus/operator/internal/resourcerequirement"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -65,6 +66,13 @@ func (r *ResourceRequirementReconciler) Reconcile(ctx context.Context, req ctrl.
 	res.Status.ApplicableResourceImplementations = implementations
 	res.Status.Status = "Not Implemented"
 	res.Status.RunAt = metav1.Now()
+	labels := map[string]string{
+		"resource":    res.Labels["argus.io/resource"],
+		"requirement": res.Labels["argus.io/requirement"],
+	}
+	metrics.GetGaugeVec(metrics.ImplementationTotalKey).With(labels).Set(float64(res.Status.TotalImplementations))
+	metrics.GetGaugeVec(metrics.ImplementationValidKey).With(labels).Set(float64(res.Status.ValidImplementations))
+
 	if res.Status.TotalImplementations == res.Status.ValidImplementations && res.Status.TotalImplementations > 0 {
 		res.Status.Status = "Implemented"
 	}

--- a/operator/internal/metrics/metrics.go
+++ b/operator/internal/metrics/metrics.go
@@ -21,6 +21,10 @@ const (
 var gaugeVecMetrics = map[string]*prometheus.GaugeVec{}
 
 func SetUpMetrics() {
+	// Only register once
+	if len(gaugeVecMetrics) == 6 {
+		return
+	}
 	// Obtain the prometheus metrics and register
 	attestationsTotal := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: "argus",

--- a/operator/internal/metrics/metrics.go
+++ b/operator/internal/metrics/metrics.go
@@ -1,0 +1,73 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var implementationLabels = []string{"resource", "implementation", "requirement"}
+var requirementLabels = []string{"resource", "requirement"}
+var resourceLabels = []string{"resource"}
+
+const (
+	AttestationTotalKey    = "attestations_total"
+	AttestationValidKey    = "attestations_valid"
+	ImplementationTotalKey = "implementations_total"
+	ImplementationValidKey = "implementations_valid"
+	RequirementTotalKey    = "requirements_total"
+	RequirementValidKey    = "requirements_valid"
+)
+
+var gaugeVecMetrics = map[string]*prometheus.GaugeVec{}
+
+func SetUpMetrics() {
+	// Obtain the prometheus metrics and register
+	attestationsTotal := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "argus",
+		Name:      "attestations_total",
+		Help:      "Total number of Attestations",
+	}, implementationLabels)
+	attestationsValid := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "argus",
+		Name:      "attestations_valid",
+		Help:      "Total number of Attestations",
+	}, implementationLabels)
+	implementationsTotal := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "argus",
+		Name:      "implementations_total",
+		Help:      "Total number of Implementations",
+	}, requirementLabels)
+	// Obtain the prometheus metrics and register
+	implementationsValid := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "argus",
+		Name:      "implementations_valid",
+		Help:      "Number of valid Implementations",
+	}, requirementLabels)
+	requirementsTotal := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "argus",
+		Name:      "requirements_total",
+		Help:      "Total number of Requirements",
+	}, resourceLabels)
+	requirementsValid := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: "argus",
+		Name:      "requirements_valid",
+		Help:      "Number of valid Requirements",
+	}, resourceLabels)
+	metrics.Registry.MustRegister(
+		attestationsTotal, attestationsValid,
+		implementationsTotal, implementationsValid,
+		requirementsTotal, requirementsValid)
+
+	gaugeVecMetrics = map[string]*prometheus.GaugeVec{
+		AttestationTotalKey:    attestationsTotal,
+		AttestationValidKey:    attestationsValid,
+		ImplementationTotalKey: implementationsTotal,
+		ImplementationValidKey: implementationsValid,
+		RequirementTotalKey:    requirementsTotal,
+		RequirementValidKey:    requirementsValid,
+	}
+}
+
+func GetGaugeVec(key string) *prometheus.GaugeVec {
+	return gaugeVecMetrics[key]
+}

--- a/operator/internal/resource/resource.go
+++ b/operator/internal/resource/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	argusiov1alpha1 "github.com/ContainerSolutions/argus/operator/api/v1alpha1"
+	"github.com/ContainerSolutions/argus/operator/internal/metrics"
 	"github.com/hashicorp/go-multierror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,6 +37,11 @@ func UpdateRequirements(resourceRequirementList argusiov1alpha1.ResourceRequirem
 	resource.Status.CompliantChildren = compliantChildren
 	resource.Status.TotalRequirements = len(resourceRequirementList.Items)
 	resource.Status.ImplementedRequirements = validRequirements
+	labels := map[string]string{
+		"resource": resource.Name,
+	}
+	metrics.GetGaugeVec(metrics.RequirementTotalKey).With(labels).Set(float64(resource.Status.TotalRequirements))
+	metrics.GetGaugeVec(metrics.RequirementValidKey).With(labels).Set(float64(resource.Status.ImplementedRequirements))
 	return resource
 }
 

--- a/operator/internal/resource/resource_test.go
+++ b/operator/internal/resource/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	argusiov1alpha1 "github.com/ContainerSolutions/argus/operator/api/v1alpha1"
+	"github.com/ContainerSolutions/argus/operator/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,7 @@ import (
 )
 
 func TestUpdateRequirements(t *testing.T) {
+	metrics.SetUpMetrics()
 	testCases := []struct {
 		name                         string
 		expectedOutput               *argusiov1alpha1.Resource
@@ -94,6 +96,7 @@ func TestUpdateRequirements(t *testing.T) {
 }
 
 func TestUpdateChild(t *testing.T) {
+	metrics.SetUpMetrics()
 	err := argusiov1alpha1.AddToScheme(scheme.Scheme)
 	require.Nil(t, err)
 	testCases := []struct {

--- a/operator/internal/resourceimplementation/resourceimplementation_test.go
+++ b/operator/internal/resourceimplementation/resourceimplementation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	argusiov1alpha1 "github.com/ContainerSolutions/argus/operator/api/v1alpha1"
+	"github.com/ContainerSolutions/argus/operator/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +16,7 @@ import (
 
 func TestListResourceAttestations(t *testing.T) {
 	commonScheme := runtime.NewScheme()
+	metrics.SetUpMetrics()
 	err := argusiov1alpha1.AddToScheme(commonScheme)
 	require.Nil(t, err)
 	testCases := []struct {

--- a/operator/internal/resourcerequirement/resourcerequirement_test.go
+++ b/operator/internal/resourcerequirement/resourcerequirement_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	argusiov1alpha1 "github.com/ContainerSolutions/argus/operator/api/v1alpha1"
+	"github.com/ContainerSolutions/argus/operator/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,7 @@ import (
 )
 
 func TestGetValidResourceImplementations(t *testing.T) {
+	metrics.SetUpMetrics()
 	commonScheme := runtime.NewScheme()
 	err := argusiov1alpha1.AddToScheme(commonScheme)
 	require.Nil(t, err)


### PR DESCRIPTION
Implements faster reconciliation by reannotating related (to trigger a reconcile)
(Possibly not the best idea as annotations has a limit in size. We'll see.)

Implements end user metrics for ResourceImplementation, ResourceRequirement and Resource.

